### PR TITLE
AddedTerms of Use (ToU) page to the website #103

### DIFF
--- a/app/terms_of_use/page.tsx
+++ b/app/terms_of_use/page.tsx
@@ -1,0 +1,135 @@
+import { Metadata } from "next";
+import RootLayout from "@/app/layout"; 
+import Link from "next/link"; 
+
+export const metadata: Metadata = {
+  title: "Terms of Use - DesignDeck",
+  description: "Read the terms of use for DesignDeck.",
+};
+
+export default function TermsOfUse() {
+  return (
+    
+    <RootLayout>
+      <div style={{
+        padding: "2rem",
+        maxWidth: "800px",
+        margin: "2rem auto",
+        border: "1px solid #ccc",
+        borderRadius: "8px",
+        boxShadow: "0 2px 10px rgba(0, 0, 0, 0.1)",
+        backgroundColor: "#f9f9f9",
+      }}>
+        <h1 style={{
+          fontSize: "2rem",
+          fontWeight: "700",
+          marginBottom: "1rem",
+          borderBottom: "2px solid #4CAF50",
+          paddingBottom: "0.5rem",
+          textAlign : "center"
+        }}>
+          Terms of Use
+          
+        </h1>
+        
+        <p style={{ lineHeight: "1.6", marginBottom: "1rem" }}>
+          Welcome to DesignDeck! These Terms of Use govern your use of our website and services. Please read these terms carefully before using our services. By accessing or using our services, you agree to comply with and be bound by these terms. If you do not agree with any part of these terms, you must not use our services.
+        </p>
+
+        <h2 style={{
+          fontSize: "1.5rem",
+          fontWeight: "600",
+          marginBottom: "1rem",
+          color: "#4CAF50",
+        }}>
+          1. Acceptance of Terms
+        </h2>
+        <p style={{ lineHeight: "1.6", marginBottom: "1rem" }}>
+          By accessing or using our services, you confirm that you accept these Terms of Use and that you agree to comply with them. If you do not agree to these terms, you must not access or use our services.
+        </p>
+
+        <h2 style={{
+          fontSize: "1.5rem",
+          fontWeight: "600",
+          marginBottom: "1rem",
+          color: "#4CAF50",
+        }}>
+          2. User Responsibilities
+        </h2>
+        <p style={{ lineHeight: "1.6", marginBottom: "1rem" }}>
+          You are responsible for your use of the services and for any content you create or share while using our services. You agree to use the services only for lawful purposes and in a manner that does not infringe the rights of, restrict, or inhibit anyone else's use and enjoyment of the services. This includes not engaging in any conduct that is unlawful, harmful, or objectionable.
+        </p>
+
+        <h2 style={{
+          fontSize: "1.5rem",
+          fontWeight: "600",
+          marginBottom: "1rem",
+          color: "#4CAF50",
+        }}>
+          3. Intellectual Property
+        </h2>
+        <p style={{ lineHeight: "1.6", marginBottom: "1rem" }}>
+          All content on DesignDeck, including text, graphics, logos, images, and software, is the property of DesignDeck or its licensors and is protected by copyright, trademark, and other intellectual property laws. You may not reproduce, distribute, modify, or create derivative works of any content without our express written permission. Any unauthorized use of the content may violate copyright, trademark, and other laws.
+        </p>
+
+        <h2 style={{
+          fontSize: "1.5rem",
+          fontWeight: "600",
+          marginBottom: "1rem",
+          color: "#4CAF50",
+        }}>
+          4. Limitation of Liability
+        </h2>
+        <p style={{ lineHeight: "1.6", marginBottom: "1rem" }}>
+          In no event shall DesignDeck be liable for any indirect, incidental, special, consequential, or punitive damages arising from your access to or use of our services. This includes any damages resulting from any errors or omissions in the content, loss of data, or any unauthorized access to or use of our servers and/or any personal information stored therein. Your use of our services is at your own risk.
+        </p>
+
+        <h2 style={{
+          fontSize: "1.5rem",
+          fontWeight: "600",
+          marginBottom: "1rem",
+          color: "#4CAF50",
+        }}>
+          5. Changes to Terms
+        </h2>
+        <p style={{ lineHeight: "1.6", marginBottom: "1rem" }}>
+          We reserve the right to modify these Terms of Use at any time. Any changes will be effective immediately upon posting the revised terms on our website. Your continued use of the services following any changes constitutes your acceptance of the new terms. We encourage you to review these terms periodically for updates.
+        </p>
+
+        <h2 style={{
+          fontSize: "1.5rem",
+          fontWeight: "600",
+          marginBottom: "1rem",
+          color: "#4CAF50",
+        }}>
+          6. Governing Law
+        </h2>
+        <p style={{ lineHeight: "1.6", marginBottom: "1rem" }}>
+          These Terms of Use shall be governed by and construed in accordance with the laws of [Your State/Country], without regard to its conflict of law provisions. Any legal action or proceeding arising out of or related to these terms shall be brought exclusively in the courts located within [Your Jurisdiction].
+        </p>
+
+        <h2 style={{
+          fontSize: "1.5rem",
+          fontWeight: "600",
+          marginBottom: "1rem",
+          color: "#4CAF50",
+        }}>
+          7. Contact Information
+        </h2>
+        <p style={{ lineHeight: "1.6", marginBottom: "1rem" }}>
+          For any questions about these Terms of Use, please contact us at [Your Email Address]. We value your feedback and are here to assist you with any concerns.
+        </p>
+
+        <p style={{ lineHeight: "1.6", marginBottom: "1rem" }}>
+          Thank you for using DesignDeck! We appreciate your trust and commitment to our services.
+        </p>
+        <br></br>
+        <Link href="/" >
+            <button className="ml-4 px-4 py-2 rounded bg-blue-500 text-white hover:bg-blue-600 transition duration-300">
+              Home
+            </button>
+          </Link>
+      </div>
+    </RootLayout>
+  );
+}

--- a/app/terms_of_use/page.tsx
+++ b/app/terms_of_use/page.tsx
@@ -9,7 +9,6 @@ export const metadata: Metadata = {
 
 export default function TermsOfUse() {
   return (
-    
     <RootLayout>
       <div style={{
         padding: "2rem",
@@ -29,7 +28,6 @@ export default function TermsOfUse() {
           textAlign : "center"
         }}>
           Terms of Use
-          
         </h1>
         
         <p style={{ lineHeight: "1.6", marginBottom: "1rem" }}>
@@ -57,7 +55,7 @@ export default function TermsOfUse() {
           2. User Responsibilities
         </h2>
         <p style={{ lineHeight: "1.6", marginBottom: "1rem" }}>
-          You are responsible for your use of the services and for any content you create or share while using our services. You agree to use the services only for lawful purposes and in a manner that does not infringe the rights of, restrict, or inhibit anyone else's use and enjoyment of the services. This includes not engaging in any conduct that is unlawful, harmful, or objectionable.
+          You are responsible for your use of the services and for any content you create or share while using our services. You agree to use the services only for lawful purposes and in a manner that does not infringe the rights of, restrict, or inhibit anyone else&apos;s use and enjoyment of the services. This includes not engaging in any conduct that is unlawful, harmful, or objectionable.
         </p>
 
         <h2 style={{
@@ -123,12 +121,13 @@ export default function TermsOfUse() {
         <p style={{ lineHeight: "1.6", marginBottom: "1rem" }}>
           Thank you for using DesignDeck! We appreciate your trust and commitment to our services.
         </p>
+
         <br></br>
         <Link href="/" >
-            <button className="ml-4 px-4 py-2 rounded bg-blue-500 text-white hover:bg-blue-600 transition duration-300">
-              Home
-            </button>
-          </Link>
+          <button className="ml-4 px-4 py-2 rounded bg-blue-500 text-white hover:bg-blue-600 transition duration-300">
+            Home
+          </button>
+        </Link>
       </div>
     </RootLayout>
   );

--- a/components/ui/footer.tsx
+++ b/components/ui/footer.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
-import { FaInstagram, FaLinkedin } from 'react-icons/fa';
+import { FaFileAlt, FaInstagram, FaLinkedin } from 'react-icons/fa';
 import { FaSquareXTwitter } from "react-icons/fa6";
-import { MdQuestionAnswer, MdEmail } from 'react-icons/md';
+import { MdQuestionAnswer, MdEmail, MdArticle } from 'react-icons/md';
 import { GiPriceTag } from 'react-icons/gi';
 import { AiOutlineUsergroupAdd } from 'react-icons/ai';
 import { LuBookMinus } from 'react-icons/lu';
@@ -113,7 +113,31 @@ const Footer = () => {
             </li>
           </ul>
         </div>
+      {/* Legal */}
+      <div>
+          <h2 className="text-xl font-semibold mb-4">Legal</h2>
+          <ul className="space-y-2">
+            <li>
+            <Link href="/terms_of_use">
+                <div className="flex items-center text-gray-400 hover:text-white">
+                <FaFileAlt className="mr-2" size={20} />
+                  Terms of Use
+                </div>
+              </Link>
+            </li>
+            <li>
+              <Link href="/privacy-policy">
+                <div className="flex items-center text-gray-400 hover:text-white">
+                <MdArticle className="mr-2" size={20} />
+                  Privacy Policy
+                </div>
+              </Link>
+            </li>
+
+          </ul>
+        </div>
       </div>
+
 
       <div className="mt-4 mb-1 border-t start-0 z-21 border-gray-700 pt-3 text-center text-gray-500">
         <div>&copy; {new Date().getFullYear()} DesignDesk. All rights reserved.</div>


### PR DESCRIPTION
This PR addresses Feature #103

I have created a **Terms of Use** page in a Next.js application with the following features:

1. **Imports**:  I have brought in components for layout and metadata handling.

2. **Metadata**: I have set the page title and description for better search engine visibility.

3. **Main Component**: The `TermsOfUse` function displays the content of the Terms of Use page.

4. **Layout and Style**: The page is organized in a styled container with headings and paragraphs for clarity.

5. **Content**: It covers key topics like user responsibilities, intellectual property, and contact info.

6. **Navigation**: A button at the bottom allows users to return to the home page, enhancing navigation.

Vedio: 

https://github.com/user-attachments/assets/911ca7a7-9f37-4d11-9bf9-27e5a29de748

Screenshot:

![Screenshot (48)](https://github.com/user-attachments/assets/9da861e9-023a-4491-979d-00eb5066f88e)

