### PR TITLE
Added nameing input to all placeholder of login and signup page

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -83,6 +83,7 @@ const LoginPage: FC = () => {
           <div>
             <label htmlFor="email" className="block text-sm font-medium">Email</label>
             <input
+             placeholder='Enter your email address'
               type="email"
               id="email"
               name="email"
@@ -97,6 +98,7 @@ const LoginPage: FC = () => {
           <div>
             <label htmlFor="username" className="block text-sm font-medium">Username</label>
             <input
+              placeholder='Enter your username'
               type="text"
               id="username"
               name="username"
@@ -111,6 +113,7 @@ const LoginPage: FC = () => {
             <label htmlFor="password" className="block text-sm font-medium">Password</label>
             <div className="relative">
               <input
+                placeholder='Enter your password'
                 type={hidden ? "password" : "text"}
                 id="password"
                 name="password"

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -64,6 +64,7 @@ const SignupPage: FC = () => {
           <div>
             <label htmlFor="username" className="block text-sm font-medium">Username</label>
             <input
+              placeholder='Enter your username'
               type="text"
               id="username"
               name="username"
@@ -77,6 +78,7 @@ const SignupPage: FC = () => {
           <div>
             <label htmlFor="email" className="block text-sm font-medium">Email</label>
             <input
+              placeholder='Enter your email address'
               type="email"
               id="email"
               name="email"
@@ -91,6 +93,7 @@ const SignupPage: FC = () => {
             <label htmlFor="password" className="block text-sm font-medium">Password</label>
             <div className="relative">
                 <input
+                placeholder='Enter your password'
                 type={hidden ? "password" : "text"}
                 id="password"
                 name="password"
@@ -111,6 +114,7 @@ const SignupPage: FC = () => {
             <label htmlFor="confirmPassword" className="block text-sm font-medium">Confirm Password</label>
             <div className="relative">
                 <input
+                placeholder='Enter your password'
                 type={confHidden ? "password" : "text"}
                 id="confirmPassword"
                 name="confirmPassword"


### PR DESCRIPTION
added naming input fileds to all placeholders of login and signup page.

 Fixes-  #258 

![WhatsApp Image 2024-11-09 at 19 02 16_5211037d](https://github.com/user-attachments/assets/9176156e-b2af-4658-a417-d6d714a62768)


![WhatsApp Image 2024-11-09 at 19 02 44_ade7f0d6](https://github.com/user-attachments/assets/0002ef94-ec46-4374-9ad6-aaf5657e45f6)
